### PR TITLE
[FIX] lock 타입을 write로 수정

### DIFF
--- a/src/main/java/com/timedeal_server/timedeal/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/timedeal_server/timedeal/domain/item/repository/ItemRepository.java
@@ -8,7 +8,7 @@ import javax.persistence.LockModeType;
 import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
-    @Lock(value= LockModeType.PESSIMISTIC_READ)
+    @Lock(value= LockModeType.PESSIMISTIC_WRITE)
     Item findByItemId(Long itemId);
 
     List<Item> findAllByUserUserId(Long userId);


### PR DESCRIPTION
## 제목
[FIX] lock 타입을 write로 수정

## 작업 내용
주문 api 성능 테스트 결과 빈번한 데드락이 발생하여 비관적락의 type을 read-> wite로 바꾸어주었음.

## 주의 사항
