### PR TITLE
[REFACTOR] deleteAll문을 수정함으로써 쿼리 문제 해결

### DIFF
--- a/src/main/java/com/timedeal_server/timedeal/domain/item/repository/ItemImageRepository.java
+++ b/src/main/java/com/timedeal_server/timedeal/domain/item/repository/ItemImageRepository.java
@@ -2,13 +2,16 @@ package com.timedeal_server.timedeal.domain.item.repository;
 
 import com.timedeal_server.timedeal.domain.item.domain.ItemImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
-
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(nativeQuery = true, value="delete from ItemImage where ItemImage.item_id=(:itemId)")
+    void deleteAllByItemId(@Param("itemId") Long itemId);
     void deleteAllByItemItemId(Long itemId);
 
     @Query(nativeQuery = true, value="select imgUrl from ItemImage where ItemImage.item_id=(:itemId)")

--- a/src/main/java/com/timedeal_server/timedeal/domain/item/service/ItemImageServiceImpl.java
+++ b/src/main/java/com/timedeal_server/timedeal/domain/item/service/ItemImageServiceImpl.java
@@ -29,10 +29,11 @@ public class ItemImageServiceImpl implements ItemImageService {
         // 폴더의 모든 이미지 삭제 후 다시 저장
         System.out.println(folderPath);
         List<String> urls = itemImageRepository.findByItemItemId(itemId);
-        urls.add(itemRepository.findById(itemId).orElseThrow(() -> new CustomException("존재하지 않는 상품입니다.")).getTitleImage());
+        Item item = itemRepository.findById(itemId).orElseThrow(() -> new CustomException("존재하지 않는 상품입니다."));
+        urls.add(item.getTitleImage());
         urls.stream().forEach(url -> s3Util.deleteFile(url, folderPath));
-        itemImageRepository.deleteAllByItemItemId(itemId);
-        Item item = itemRepository.findById(itemId).orElseThrow(() -> new CustomException("존재하지 않는 상품 번호입니다."));
+        //itemImageRepository.deleteAllByItemItemId(itemId);
+        itemImageRepository.deleteAllByItemId(itemId);
         String titleImage = save(item, folderPath, titleFile, images);
         item.setTitleImage(titleImage);
         itemRepository.save(item);


### PR DESCRIPTION
## 제목
[REFACTOR] deleteAll문을 수정함으로써 쿼리 문제 해결

## 작업 내용
jpa deleteAllBy를 사용하면 쿼리문이 for문 처럼 삭제해야 하는 갯수만큼 반복해서 날라가는 문제를 해결하기 위해 직접 쿼리문을 작성해주었음

## 주의 사항